### PR TITLE
 Allow browser choice to be specified at runtime.

### DIFF
--- a/.factorypath
+++ b/.factorypath
@@ -1,25 +1,55 @@
 <factorypath>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-java/3.8.1/selenium-java-3.8.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-api/3.8.1/selenium-api-3.8.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-chrome-driver/3.8.1/selenium-chrome-driver-3.8.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-edge-driver/3.8.1/selenium-edge-driver-3.8.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-ie-driver/3.8.1/selenium-ie-driver-3.8.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-opera-driver/3.8.1/selenium-opera-driver-3.8.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-remote-driver/3.8.1/selenium-remote-driver-3.8.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-safari-driver/3.8.1/selenium-safari-driver-3.8.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-support/3.8.1/selenium-support-3.8.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/net/bytebuddy/byte-buddy/1.7.5/byte-buddy-1.7.5.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-java/3.13.0/selenium-java-3.13.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-api/3.13.0/selenium-api-3.13.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-chrome-driver/3.13.0/selenium-chrome-driver-3.13.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-edge-driver/3.13.0/selenium-edge-driver-3.13.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-ie-driver/3.13.0/selenium-ie-driver-3.13.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-opera-driver/3.13.0/selenium-opera-driver-3.13.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-remote-driver/3.13.0/selenium-remote-driver-3.13.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-safari-driver/3.13.0/selenium-safari-driver-3.13.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-support/3.13.0/selenium-support-3.13.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/net/bytebuddy/byte-buddy/1.8.3/byte-buddy-1.8.3.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/commons/commons-exec/1.3/commons-exec-1.3.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/commons-codec/commons-codec/1.10/commons-codec-1.10.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/commons-logging/commons-logging/1.2/commons-logging-1.2.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/code/gson/gson/2.8.2/gson-2.8.2.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/guava/guava/23.0/guava-23.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/code/gson/gson/2.8.4/gson-2.8.4.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/guava/guava/25.0-jre/guava-25.0-jre.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/errorprone/error_prone_annotations/2.0.18/error_prone_annotations-2.0.18.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/httpcomponents/httpclient/4.5.5/httpclient-4.5.5.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/squareup/okhttp3/okhttp/3.10.0/okhttp-3.10.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/squareup/okio/okio/1.14.1/okio-1.14.1.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/beust/jcommander/1.27/jcommander-1.27.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/yaml/snakeyaml/1.6/snakeyaml-1.6.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-server/3.13.0/selenium-server-3.13.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/commons/commons-lang3/3.7/commons-lang3-3.7.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/commons/commons-text/1.1/commons-text-1.1.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/commons-net/commons-net/3.6/commons-net-3.6.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/net/sourceforge/htmlunit/htmlunit/2.30/htmlunit-2.30.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/net/sourceforge/htmlunit/htmlunit-core-js/2.28/htmlunit-core-js-2.28.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/net/sourceforge/htmlunit/htmlunit-cssparser/1.0.0/htmlunit-cssparser-1.0.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/net/sourceforge/htmlunit/neko-htmlunit/2.30/neko-htmlunit-2.30.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/httpcomponents/httpmime/4.5.5/httpmime-4.5.5.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/jetty-repacked/9.4.7.v20171121/jetty-repacked-9.4.7.v20171121.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/eclipse/jetty/jetty-client/9.4.7.v20170914/jetty-client-9.4.7.v20170914.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/eclipse/jetty/jetty-http/9.4.8.v20171121/jetty-http-9.4.8.v20171121.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/eclipse/jetty/jetty-io/9.4.8.v20171121/jetty-io-9.4.8.v20171121.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/eclipse/jetty/jetty-util/9.4.8.v20171121/jetty-util-9.4.8.v20171121.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/eclipse/jetty/jetty-xml/9.4.7.v20170914/jetty-xml-9.4.7.v20170914.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/htmlunit-driver/2.30.0/htmlunit-driver-2.30.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/eclipse/jetty/websocket/websocket-api/9.4.7.v20170914/websocket-api-9.4.7.v20170914.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/eclipse/jetty/websocket/websocket-client/9.4.7.v20170914/websocket-client-9.4.7.v20170914.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/eclipse/jetty/websocket/websocket-common/9.4.7.v20170914/websocket-common-9.4.7.v20170914.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/xalan/serializer/2.7.2/serializer-2.7.2.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/xalan/xalan/2.7.2/xalan-2.7.2.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/xerces/xercesImpl/2.11.0/xercesImpl-2.11.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/xml-apis/xml-apis/1.4.01/xml-apis-1.4.01.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/seleniumhq/selenium/selenium-firefox-driver/3.8.1/selenium-firefox-driver-3.8.1.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/poi/poi/3.16/poi-3.16.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/commons/commons-collections4/4.1/commons-collections4-4.1.jar" enabled="true" runInBatchMode="false"/>
@@ -31,18 +61,11 @@
     <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/commons/commons-email/1.3.2/commons-email-1.3.2.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/javax/mail/mail/1.4.5/mail-1.4.5.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/javax/activation/activation/1.1.1/activation-1.1.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/com/relevantcodes/extentreports/2.41.2/extentreports-2.41.2.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/jsoup/jsoup/1.8.3/jsoup-1.8.3.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/xerial/sqlite-jdbc/3.8.11.1/sqlite-jdbc-3.8.11.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/mongodb/mongodb-driver/3.0.4/mongodb-driver-3.0.4.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/mongodb/bson/3.0.4/bson-3.0.4.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/mongodb/mongodb-driver-core/3.0.4/mongodb-driver-core-3.0.4.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/logging/log4j/log4j-api/2.3/log4j-api-2.3.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/logging/log4j/log4j-core/2.3/log4j-core-2.3.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/commons-io/commons-io/1.3.2/commons-io-1.3.2.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/net/lightbody/bmp/browsermob-core/2.1.5/browsermob-core-2.1.5.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/net/lightbody/bmp/littleproxy/1.1.0-beta-bmp-17/littleproxy-1.1.0-beta-bmp-17.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/fasterxml/jackson/core/jackson-annotations/2.8.9/jackson-annotations-2.8.9.jar" enabled="true" runInBatchMode="false"/>
@@ -54,5 +77,11 @@
     <factorypathentry kind="VARJAR" id="M2_REPO/org/bouncycastle/bcprov-jdk15on/1.58/bcprov-jdk15on-1.58.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/bouncycastle/bcpkix-jdk15on/1.58/bcpkix-jdk15on-1.58.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/net/lightbody/bmp/mitm/2.1.5/mitm-2.1.5.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/relevantcodes/extentreports/2.41.2/extentreports-2.41.2.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/jsoup/jsoup/1.8.3/jsoup-1.8.3.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/xerial/sqlite-jdbc/3.8.11.1/sqlite-jdbc-3.8.11.1.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/mongodb/mongodb-driver/3.0.4/mongodb-driver-3.0.4.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/mongodb/bson/3.0.4/bson-3.0.4.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/mongodb/mongodb-driver-core/3.0.4/mongodb-driver-core-3.0.4.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/freemarker/freemarker/2.3.23/freemarker-2.3.23.jar" enabled="true" runInBatchMode="false"/>
 </factorypath>

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Allow developers to have a local script for their desired configuration
+/run.bat
+/run.cmd
+/run.sh
+
 /.settings
 /target
 /test-output

--- a/README.md
+++ b/README.md
@@ -19,7 +19,22 @@ To execute a specific test suite, execute the command
 Where `<testfile>` is the test suite file and path.  Multiple test suites may be specified by separating them
 with commas. e.g.
 
-    mvn test -Dsurefire.suiteXmlFiles=resources\testng-CTS.xml,resources\testng-R4R.xml 
+    mvn test -Dsurefire.suiteXmlFiles=resources\testng-CTS.xml,resources\testng-R4R.xml
+
+Tests default to running in Chrome Headless. To use a different browser, include the arguement -Dbrowser=<browser>
+
+    mvn test -Dbrowser=Chrome
+
+Valid browser names are:
+* Chrome
+* ChromeHeadless
+* Firefox
+* GeckoHeadless
+* iPhone6
+* iPad
+
+**NOTE:** Names are CaSe seNstive.  (e.g. "Chrome" is not the same as "chrome.")
+
 
 ## Setup For Eclipse
 1. Open Eclipse and workspace.

--- a/pom.xml
+++ b/pom.xml
@@ -99,12 +99,12 @@
       <version>2.3</version>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-io -->
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>1.3.2</version>
-    </dependency>
+    <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+  <dependency>
+    <groupId>commons-io</groupId>
+    <artifactId>commons-io</artifactId>
+    <version>1.3.2</version>
+  </dependency>
 
     <!-- https://mvnrepository.com/artifact/net.lightbody.bmp/browsermob-core -->
     <dependency>
@@ -149,7 +149,6 @@
                   GeckoHeadless
                   iPhone6
                   iPad
-
             -->
             <browser>ChromeHeadless</browser>
           </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		Set up the default test suite to run if one isn't specified from mvn command line.
 		(override with "-Dsurefire.suiteXmlFiles=<testfile>", specifying a path if needed.)
 	-->
-    <smokeSuiteFile>resources/testng-CTS.xml</smokeSuiteFile>
+    <smokeSuiteFile>resources/testng-All.xml</smokeSuiteFile>
     <defaultSuiteFiles>${smokeSuiteFile}</defaultSuiteFiles>
     <suiteFile>${defaultSuiteFiles}</suiteFile>
 
@@ -32,12 +32,13 @@
     </dependency>
 
     <!-- Java API to access the Client Driver Protocols -->
-    <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-java -->
-    <dependency>
-      <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>selenium-java</artifactId>
-      <version>3.8.1</version>
-    </dependency>
+ <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-java -->
+<dependency>
+    <groupId>org.seleniumhq.selenium</groupId>
+    <artifactId>selenium-java</artifactId>
+    <version>3.13.0</version>
+</dependency>
+
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
@@ -46,6 +47,16 @@
       <!--  scope>compile</scope>-->
     </dependency>
 
+<!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-server -->
+<dependency>
+    <groupId>org.seleniumhq.selenium</groupId>
+    <artifactId>selenium-server</artifactId>
+    <version>3.13.0</version>
+</dependency>
+
+
+	
+	
     <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-firefox-driver -->
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
@@ -74,12 +85,7 @@
       <version>1.3.2</version>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/com.relevantcodes/extentreports -->
-    <dependency>
-      <groupId>com.relevantcodes</groupId>
-      <artifactId>extentreports</artifactId>
-      <version>2.41.2</version>
-    </dependency>
+
 
     <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
     <dependency>
@@ -93,9 +99,9 @@
       <version>2.3</version>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+    <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-io -->
     <dependency>
-      <groupId>commons-io</groupId>
+      <groupId>org.apache.commons</groupId>
       <artifactId>commons-io</artifactId>
       <version>1.3.2</version>
     </dependency>
@@ -106,7 +112,12 @@
       <artifactId>browsermob-core</artifactId>
       <version>2.1.5</version>
     </dependency>
-
+    <dependency>
+      <groupId>com.relevantcodes</groupId>
+      <artifactId>extentreports</artifactId>
+      <version>2.41.2</version>
+    </dependency>
+ 
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
@@ -127,6 +138,21 @@
           <suiteXmlFiles>
             <suiteXmlFile>${suiteFile}</suiteXmlFile>
           </suiteXmlFiles>
+          <systemPropertyVariables>
+            <!-- To use a different browser, on the maven command line, specify
+                `-Dbrowser=<browser_name>`
+
+                Valid values are:
+                  Chrome
+                  ChromeHeadless
+                  Firefox
+                  GeckoHeadless
+                  iPhone6
+                  iPad
+
+            -->
+            <browser>ChromeHeadless</browser>
+          </systemPropertyVariables>
         </configuration>
 
       </plugin>

--- a/resources/testanalytics.xml
+++ b/resources/testanalytics.xml
@@ -1,40 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="QA Environment" parallel="none">
-	<!--
-	<test name="NCI - Chrome Testing" >
-		<parameter name="browser" value="Chrome" />
-		<groups>
-			<run>
-				<include name="Analytics" />
-			</run>
-		</groups>
-		<classes>
-			<class name="gov.nci.WebAnalytics.Tests.PageLoad_Test" />
-			<class name="gov.nci.WebAnalytics.Tests.Resize_Test" />
-			<class name="gov.nci.WebAnalytics.Tests.MegaMenu_Test" />
-			<class name="gov.nci.WebAnalytics.Tests.Sandbox_Test" />
-		</classes>
-	</test>
-	-->
-	<!--
-	<test name="NCI - Firefox Testing" >
-		<parameter name="browser" value="Firefox" />
-		<groups>
-			<run>
-				<include name="Analytics" />
-			</run>
-		</groups>
-		<classes>
-			<class name="gov.nci.WebAnalytics.Tests.PageLoad_Test" />
-			<class name="gov.nci.WebAnalytics.Tests.Resize_Test" />
-			<class name="gov.nci.WebAnalytics.Tests.MegaMenu_Test" />
-			<class name="gov.nci.WebAnalytics.Tests.Sandbox_Test" />
-		</classes>
-	</test>
-	-->
 	<test name="NCI - Gecko Testing Headless" >
-		<parameter name="browser" value="GeckoHeadless" />
+		<!--
+			The browser parameter is set in pom.xml as part of invoking
+			the maven-surefire-plugin.
+
+			<parameter name="browser" value="Chrome" />
+		-->
 		<groups>
 			<run>
 				<include name="Analytics" />

--- a/resources/testng-All.xml
+++ b/resources/testng-All.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="NCI Automation - All Test Cases" parallel="none">
+	  <test name="NCI - Chrome Testing" preserve-order="true">
+		<!--
+			The browser parameter is set in pom.xml as part of invoking
+			the maven-surefire-plugin.
+
+			<parameter name="browser" value="Chrome" />
+		-->
+		<groups>
+			<run>
+				<include name="Smoke" />
+			</run>
+		</groups>
+		<classes> 	
+			  <class name="gov.nci.clinicaltrials.BasicSearch_Test" />
+			  <class name="gov.nci.clinicaltrials.AdvanceSearch_Test" /> 
+			  <!-- <class name="gov.nci.clinicaltrials.AdvanceSearchResults_Test" /> 
+			  <class name="gov.nci.Resources4Researchers.Tests.Resources4Researchers_Test" /> 
+			  <class name="gov.nci.Resources4Researchers.Tests.Resources4ResearchersSearchResult_Test" />
+			  <class name="gov.nci.CommonObjects.Tests.LanguageBar_Test" />
+			  <class name="gov.nci.CommonObjects.Tests.UtilityNav_Test" /> 
+			   
+			  <class name="gov.nci.clinicaltrials.BasicSearchResults_Test" />
+			  --> 
+		</classes>
+	</test> 
+
+</suite>
+

--- a/resources/testng-CTS.xml
+++ b/resources/testng-CTS.xml
@@ -2,7 +2,12 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="QA Environment2" parallel="none">
 	  <test name="NCI - Chrome Testing" preserve-order="true">
-		<parameter name="browser" value="Chrome" />
+		<!--
+			The browser parameter is set in pom.xml as part of invoking
+			the maven-surefire-plugin.
+
+			<parameter name="browser" value="Chrome" />
+		-->
 		<groups>
 			<run>
 				<include name="Smoke" />
@@ -18,74 +23,6 @@
 			    
 		</classes>
 	</test> 
-	
-	<!--  <test name="NCI - iPhone Testing" >
-		<parameter name="browser" value="iPhone6" />
-		<groups>
-			<run>
-				<include name="Smoke" />
-			</run>
-		</groups>
-		<classes> 	
-			 <class name="gov.nci.clinicaltrials.BasicSearch_Test" /> 
-			<class name="gov.nci.clinicaltrials.AdvanceSearch_Test" />
-			
-			 
-			  <class name="gov.nci.clinicaltrials.AdvanceSearchResults_Test" />  
-			
-		</classes>
-	</test>  -->
-	
-	<!--  <test name="NCI - iPad Testing" >
-		<parameter name="browser" value="iPad" />
-		<groups>
-			<run>
-				<include name="Smoke" />
-			</run>
-		</groups>
-		<classes> 	
-		 <class name="gov.nci.clinicaltrials.BasicSearch_Test" /> 
-		<class name="gov.nci.clinicaltrials.AdvanceSearch_Test" />
-			
-		 <class name="gov.nci.clinicaltrials.AdvanceSearchResults_Test" /> 
-			
-		</classes>
-	</test> -->
-	<!--<test name="NCI - Chrome Testing Headless" >
-		<parameter name="browser" value="ChromeHeadless" />
-		<groups>
-			<run>
-				<include name="Smoke" />
-			</run>
-		</groups>
-		<classes> 	
-			<class name="gov.nci.clinicaltrials.BasicSearch_Test" />
-		<class name="gov.nci.clinicaltrials.AdvanceSearch_Test" />
-		</classes>
-	</test>  -->
-	<!--   <test name="NCI - Firefox Testing" >
-		<parameter name="browser" value="Firefox" />
-		<groups>
-			<run>
-				<include name="Smoke" />
-			</run>
-		</groups>
-		<classes> 	
-			 <class name="gov.nci.clinicaltrials.BasicSearch_Test" /> 
-			   <class name="gov.nci.clinicaltrials.AdvanceSearch_Test" />
-		</classes>
-	</test>  --> 
-	<!-- <test name="NCI - Firefox Testing Headless" >
-		<parameter name="browser" value="FirefoxHeadless" />
-		<groups>
-			<run>
-				<include name="Smoke" />
-			</run>
-		</groups>
-		<classes> 	
-			<class name="gov.nci.clinicaltrials.BasicSearch_Test" />
-			  <class name="gov.nci.clinicaltrials.AdvanceSearch_Test" /> 
-		</classes>
-	</test>   -->
+
 </suite>
 

--- a/resources/testng-R4R.xml
+++ b/resources/testng-R4R.xml
@@ -2,90 +2,22 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="QA Environment1" parallel="none">
 	  <test name="NCI - Chrome Testing" preserve-order="true">
-		<parameter name="browser" value="Chrome" />
+		<!--
+			The browser parameter is set in pom.xml as part of invoking
+			the maven-surefire-plugin.
+
+			<parameter name="browser" value="Chrome" />
+		-->
 		<groups>
 			<run>
-				<include name="current" />
+				<include name="Smoke" />
 			</run>
 		</groups>
-		<classes> 	
-			 <class name="gov.nci.clinicaltrials.BasicSearch_Test" /> 
-			 
-			    
-			  <!--    	
-			  <class name="gov.nci.clinicaltrials.AdvanceSearch_Test" />
-			  <class name="gov.nci.clinicaltrials.AdvanceSearchResults_Test" />  --> 	
-
+		<classes> 	 
+			  <class name="gov.nci.Resources4Researchers.Tests.Resources4Researchers_Test" /> 
+			   <class name="gov.nci.Resources4Researchers.Tests.Resources4ResearchersSearchResult_Test" />	
 		</classes>
 	</test> 
 	
-	<!--  <test name="NCI - iPhone Testing" >
-		<parameter name="browser" value="iPhone6" />
-		<groups>
-			<run>
-				<include name="Smoke" />
-			</run>
-		</groups>
-		<classes> 	
-			 <class name="gov.nci.clinicaltrials.BasicSearch_Test" /> 
-			<class name="gov.nci.clinicaltrials.AdvanceSearch_Test" />
-			
-			 
-			  <class name="gov.nci.clinicaltrials.AdvanceSearchResults_Test" />  
-			
-		</classes>
-	</test>  -->
-	
-	<!--  <test name="NCI - iPad Testing" >
-		<parameter name="browser" value="iPad" />
-		<groups>
-			<run>
-				<include name="Smoke" />
-			</run>
-		</groups>
-		<classes> 	
-		 <class name="gov.nci.clinicaltrials.BasicSearch_Test" /> 
-		<class name="gov.nci.clinicaltrials.AdvanceSearch_Test" />
-			
-		 <class name="gov.nci.clinicaltrials.AdvanceSearchResults_Test" /> 
-			
-		</classes>
-	</test> -->
-	<!--<test name="NCI - Chrome Testing Headless" >
-		<parameter name="browser" value="ChromeHeadless" />
-		<groups>
-			<run>
-				<include name="Smoke" />
-			</run>
-		</groups>
-		<classes> 	
-			<class name="gov.nci.clinicaltrials.BasicSearch_Test" />
-		<class name="gov.nci.clinicaltrials.AdvanceSearch_Test" />
-		</classes>
-	</test>  -->
-	<!--   <test name="NCI - Firefox Testing" >
-		<parameter name="browser" value="Firefox" />
-		<groups>
-			<run>
-				<include name="Smoke" />
-			</run>
-		</groups>
-		<classes> 	
-			 <class name="gov.nci.clinicaltrials.BasicSearch_Test" /> 
-			   <class name="gov.nci.clinicaltrials.AdvanceSearch_Test" />
-		</classes>
-	</test>  --> 
-	<!-- <test name="NCI - Firefox Testing Headless" >
-		<parameter name="browser" value="FirefoxHeadless" />
-		<groups>
-			<run>
-				<include name="Smoke" />
-			</run>
-		</groups>
-		<classes> 	
-			<class name="gov.nci.clinicaltrials.BasicSearch_Test" />
-			  <class name="gov.nci.clinicaltrials.AdvanceSearch_Test" /> 
-		</classes>
-	</test>   -->
 </suite>
 

--- a/src/main/java/gov/nci/clinicalTrial/pages/AdvanceSearch.java
+++ b/src/main/java/gov/nci/clinicalTrial/pages/AdvanceSearch.java
@@ -1,5 +1,7 @@
 package gov.nci.clinicalTrial.pages;
 
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -13,7 +15,7 @@ import org.openqa.selenium.support.PageFactory;
 
 import gov.nci.Utilities.ScrollUtil;
 
-public class AdvanceSearch {
+public class AdvanceSearch extends ClinicalTrialPageObjectBase {
 
 	public static final String ADVANCE_SEARCH_PAGE_TITLE = "Find NCI-Supported Clinical Trials";
 	public static final String SEARCH_RESULT_PAGE_TITLE = "Clinical Trials Search Results";
@@ -149,7 +151,8 @@ public class AdvanceSearch {
 	WebElement showSearchCriteria;
 
 	// Initializing the Page Objects
-	public AdvanceSearch(WebDriver driver) {
+	public AdvanceSearch(WebDriver driver, ClinicalTrialPageObjectBase decorator) throws MalformedURLException, UnsupportedEncodingException {
+		super(driver, decorator);
 		this.driver = driver;
 		PageFactory.initElements(driver, this);
 	}

--- a/src/main/java/gov/nci/clinicalTrial/pages/AdvanceSearchResults.java
+++ b/src/main/java/gov/nci/clinicalTrial/pages/AdvanceSearchResults.java
@@ -1,5 +1,7 @@
 package gov.nci.clinicalTrial.pages;
 
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.util.List;
 
 import org.openqa.selenium.JavascriptExecutor;
@@ -9,7 +11,7 @@ import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.How;
 import org.openqa.selenium.support.PageFactory;
 
-public class AdvanceSearchResults {
+public class AdvanceSearchResults extends ClinicalTrialPageObjectBase {
 	public static final String SEARCH_RESULT_PAGE_TITLE = "Clinical Trials Search Results";
 	public static final String BREAD_CRUMB = "Home\nAbout Cancer\nCancer Treatment\nClinical Trials Information\nFind NCI-Supported Clinical Trials";
 	public static final String H1_TITLE = "Clinical Trials Search Results";
@@ -45,7 +47,8 @@ public class AdvanceSearchResults {
 	List<WebElement> checkBoxes3;
 
 	/********** Constructor: Initializing the Page Objects *****************/
-	public AdvanceSearchResults(WebDriver driver) {
+	public AdvanceSearchResults(WebDriver driver, ClinicalTrialPageObjectBase decorator) throws MalformedURLException, UnsupportedEncodingException{
+		super(driver, decorator);
 		this.driver = driver;
 		PageFactory.initElements(driver, this);
 	}

--- a/src/test/java/gov/nci/clinicaltrials/AdvanceSearchResults_Test.java
+++ b/src/test/java/gov/nci/clinicaltrials/AdvanceSearchResults_Test.java
@@ -11,6 +11,7 @@ import org.testng.annotations.Test;
 
 import gov.nci.Utilities.BrowserManager;
 import gov.nci.clinicalTrial.pages.AdvanceSearchResults;
+import gov.nci.clinicalTrial.pages.SuppressChatPromptPageObject;
 import gov.nci.commonobjects.Banner;
 import gov.nci.commonobjects.BreadCrumb;
 import com.relevantcodes.extentreports.LogStatus;
@@ -29,7 +30,14 @@ public class AdvanceSearchResults_Test extends BaseClass {
 		System.out.println("PageURL: " + pageURL);
 		driver = BrowserManager.startBrowser(browser, pageURL);
 
-		advanceSearchResults = new AdvanceSearchResults(driver);
+		try {
+			SuppressChatPromptPageObject chatBlock = new SuppressChatPromptPageObject(driver, null);
+			advanceSearchResults = new AdvanceSearchResults(driver, chatBlock);
+		} catch (Exception e) {
+			advanceSearchResults = null;
+			logger.log(LogStatus.ERROR, "Error creating Advanced Search page.");
+		}
+
 		System.out.println("Advance Search Results setup done");
 		crumb = new BreadCrumb(driver);
 		

--- a/src/test/java/gov/nci/clinicaltrials/AdvanceSearch_Test.java
+++ b/src/test/java/gov/nci/clinicaltrials/AdvanceSearch_Test.java
@@ -17,6 +17,7 @@ import org.testng.annotations.Test;
 import gov.nci.Utilities.BrowserManager;
 import gov.nci.Utilities.ExcelManager;
 import gov.nci.clinicalTrial.pages.AdvanceSearch;
+import gov.nci.clinicalTrial.pages.SuppressChatPromptPageObject;
 import gov.nci.clinicalTrial.common.ApiReference;
 import gov.nci.clinicalTrial.common.Delighters;
 import gov.nci.commonobjects.Banner;
@@ -42,7 +43,14 @@ public class AdvanceSearch_Test extends BaseClass {
 		System.out.println("PageURL: " + pageURL);
 		driver = BrowserManager.startBrowser(browser, pageURL);
 
-		advanceSearch = new AdvanceSearch(driver);
+		try {
+			SuppressChatPromptPageObject chatBlock = new SuppressChatPromptPageObject(driver, null);
+			advanceSearch = new AdvanceSearch(driver, chatBlock);
+		} catch (Exception e) {
+			advanceSearch = null;
+			logger.log(LogStatus.ERROR, "Error creating Advanced Search page.");
+		}
+
 		System.out.println("Advance Search setup done");
 		delighter = new Delighters(driver);
 		crumb = new BreadCrumb(driver);

--- a/src/test/java/gov/nci/clinicaltrials/BaseClass.java
+++ b/src/test/java/gov/nci/clinicaltrials/BaseClass.java
@@ -3,7 +3,6 @@ package gov.nci.clinicaltrials;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterClass;
@@ -14,12 +13,12 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Parameters;
 
-import gov.nci.Utilities.ConfigReader;
-import gov.nci.Utilities.ScreenShot;
-
 import com.relevantcodes.extentreports.ExtentReports;
 import com.relevantcodes.extentreports.ExtentTest;
 import com.relevantcodes.extentreports.LogStatus;
+
+import gov.nci.Utilities.ConfigReader;
+import gov.nci.Utilities.ScreenShot;
 
 public class BaseClass {
 
@@ -58,7 +57,7 @@ public class BaseClass {
 		// TODO: explicitly load the page in each test.
 		driver.get(pageURL);
 
-		((JavascriptExecutor) driver).executeScript("scroll(0, -100);");
+		//((JavascriptExecutor) driver).executeScript("scroll(0, -100);");
 	}
 
 	@AfterMethod(groups = { "Smoke", "current" })
@@ -71,9 +70,7 @@ public class BaseClass {
 		} else if (result.getStatus() == ITestResult.SKIP) {
 			logger.log(LogStatus.SKIP, "Skipped => " + result.getName());
 		}
-		else {
-			logger.log(LogStatus.PASS, "Pass => "+ result.getName());
-		}
+
 	}
 
 	@AfterClass(groups = { "Smoke", "current" })


### PR DESCRIPTION
Removes the hard-coded browser parameter from the testng file and
put it in the pom.xml where it can be specified at runtime via

    -Dbrowser=<browser_name>

valid browser names are:

* Chrome
* ChromeHeadless
* Firefox
* GeckoHeadless
* iPhone6
* iPad